### PR TITLE
Calorie count endpoint

### DIFF
--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -47,8 +47,19 @@ router.get('/calorie_search', function(req, res, next) {
     limit: 3
   })
   .then(recipes => {
-    res.setHeader('Content-Type', 'application/json');
-    res.status(200).send(JSON.stringify(recipes));
+    if (recipes.length < 3) {
+      edamamService.calorieTotal(req.query.q, req.query.calories)
+      .then(data => {
+        Recipe.bulkCreate(data)
+        .then(recipeResources => {
+          res.setHeader('Content-Type', 'application/json');
+          res.status(200).send(JSON.stringify(recipeResources));
+        })
+      })
+    } else {
+      res.setHeader('Content-Type', 'application/json');
+      res.status(200).send(JSON.stringify(recipes));
+    }
   })
   .catch(error => {
     res.setHeader('Content-Type', 'application/json');

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var router = express.Router();
-const Op = require('../../../models').Sequelize.Op;
+var Sequelize = require('../../../models').Sequelize
+var Op = Sequelize.Op;
 var Recipe = require('../../../models').Recipe
 var Edamam = require('../../../services/edamam').Edamam
 var edamamService = new Edamam
@@ -34,10 +35,13 @@ router.get('/food_search', function(req, res, next) {
 })
 
 router.get('/calorie_search', function(req, res, next) {
+  var maxCalories = req.query.calories + 101
+  var minCalories = req.query.calories - 101
   Recipe.findAll({
     where: {
+      foodType: req.query.q,
       calorieCount: {
-        [Op.between]: [(req.query.calories + 100), (req.query.calories - 100)]
+        [Op.between]: [minCalories, maxCalories]
       }
     },
     limit: 3

--- a/services/edamam.js
+++ b/services/edamam.js
@@ -26,7 +26,9 @@ class Edamam {
  }
 
   calorieTotal(food, calories) {
-   return fetch(`https://api.edamam.com/search?q=${food}&app_id=${process.env.EDAMAM_API_ID}&app_key=${process.env.EDAMAM_API_KEY}&to=3&calories=${calories}`)
+   var maxCalories = calories + 100
+   var minCalories = calories - 100
+   return fetch(`https://api.edamam.com/search?q=${food}&app_id=${process.env.EDAMAM_API_ID}&app_key=${process.env.EDAMAM_API_KEY}&to=3&calories=${minCalories}-${maxCalories}`)
    .then(response => {
      return response.json()
      .then(json => {

--- a/services/edamam.js
+++ b/services/edamam.js
@@ -24,6 +24,29 @@ class Edamam {
      })
    })
  }
+
+  calorieTotal(food, calories) {
+   return fetch(`https://api.edamam.com/search?q=${food}&app_id=${process.env.EDAMAM_API_ID}&app_key=${process.env.EDAMAM_API_KEY}&to=3&calories=${calories}`)
+   .then(response => {
+     return response.json()
+     .then(json => {
+       let recipes = []
+       json.hits.forEach(function(recipe) {
+         recipes.push({
+           name: recipe.recipe.label,
+           foodType: food,
+           recipeUrl: recipe.recipe.url,
+           recipeImage: recipe.recipe.image,
+           ingredientList: recipe.recipe.ingredientLines.join(','),
+           ingredientCount: recipe.recipe.ingredientLines.length,
+           calorieCount: recipe.recipe.calories,
+           servingCount: recipe.recipe.yield
+         })
+       })
+       return recipes
+     })
+   })
+ }
 }
 
 module.exports = {

--- a/test/calorie_count.spec.js
+++ b/test/calorie_count.spec.js
@@ -3,6 +3,8 @@ var request = require("supertest");
 var app = require('../app');
 var cleanup = require('./helper/testCleanup');
 var Recipe = require('../models').Recipe
+var Sequelize = require('../models').Sequelize
+var Op = Sequelize.Op;
 
 describe('Calorie count api', () => {
   beforeEach(() => {
@@ -57,4 +59,37 @@ describe('Calorie count api', () => {
         })
       })
     })
+
+    test('it can use edamam to get 3 recipes with the given calorie count if none are found', () => {
+        return Recipe.findAll({
+          where: {
+            foodType: 'turkey'
+          }
+        })
+        .then(recipes => {
+          expect(recipes.length).toBe(0)
+
+          return request(app).get('/api/v1/recipes/calorie_search?q=turkey&calories=2000')
+          .then(response => {
+            expect(response.statusCode).toBe(200)
+            expect(response.body.length).toBe(3)
+            expect(Object.keys(response.body[0])).toContain('id')
+            expect(Object.keys(response.body[0])).toContain('name')
+            expect(Object.keys(response.body[0])).toContain('recipeUrl')
+            expect(Object.keys(response.body[0])).toContain('recipeImage')
+            expect(Object.keys(response.body[0])).toContain('ingredientList')
+            expect(Object.keys(response.body[0])).toContain('calorieCount')
+            expect(Object.keys(response.body[0])).toContain('servingCount')
+
+            return Recipe.findAll({
+              where: {
+                foodType: 'turkey'
+              }
+            })
+            .then(recipes => {
+              expect(recipes.length).toBe(3)
+            })
+          })
+        })
+      })
   })

--- a/test/calorie_count.spec.js
+++ b/test/calorie_count.spec.js
@@ -42,7 +42,7 @@ describe('Calorie count api', () => {
         servingCount: 4
       }])
       .then(recipes => {
-        return request(app).get('/api/v1/recipes/calorie_search?calories=2000')
+        return request(app).get('/api/v1/recipes/calorie_search?q=chicken&calories=2000')
           .then(response => {
             expect(response.statusCode).toBe(200)
             expect(response.body.length).toBe(3)

--- a/test/services/edamam.spec.js
+++ b/test/services/edamam.spec.js
@@ -24,4 +24,19 @@ describe('Edamam API Service Tests', () => {
       expect(Object.keys(recipes[0])).toContain('servingCount')
     })
   })
+
+  test('It can get recipes by food type and calories', () => {
+    return edamamService.calorieTotal('turkey', 2000)
+    .then(recipes => {
+      expect(recipes.length).toBe(3)
+      expect(Object.keys(recipes[0])).toContain('name')
+      expect(recipes[0].foodType).toBe('turkey')
+      expect(Object.keys(recipes[0])).toContain('recipeUrl')
+      expect(Object.keys(recipes[0])).toContain('recipeImage')
+      expect(Object.keys(recipes[0])).toContain('ingredientList')
+      expect(Object.keys(recipes[0])).toContain('ingredientCount')
+      expect(Object.keys(recipes[0])).toContain('calorieCount')
+      expect(Object.keys(recipes[0])).toContain('servingCount')
+    })
+  })
 })


### PR DESCRIPTION
This PR:

Adds functionality for the '/api/v1/recipes/calorie_search' endpoint
When 3 are found from the datatbase within +-100 calories given in the query params, those 3 are returned. If not, we reach out to the edamam API and find 3, save them to our database, and then return them