### PR TITLE
Ingredient Search Endpoint

### DIFF
--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -61,19 +61,19 @@ router.get('/ingredient_search', function(req, res, next) {
     limit: 3
   })
   .then(recipes => {
-    // if (recipes.length < 3) {
-    //   edamamService.foodType(req.query.q)
-    //   .then(data => {
-    //     Recipe.bulkCreate(data)
-    //     .then(recipeResources => {
-    //       res.setHeader('Content-Type', 'application/json');
-    //       res.status(200).send(JSON.stringify(recipeResources));
-    //     })
-    //   })
-    // } else {
+    if (recipes.length < 3) {
+      edamamService.ingredientCount(req.query.q, req.query.num_of_ingredients)
+      .then(data => {
+        Recipe.bulkCreate(data)
+        .then(recipeResources => {
+          res.setHeader('Content-Type', 'application/json');
+          res.status(200).send(JSON.stringify(recipeResources));
+        })
+      })
+    } else {
       res.setHeader('Content-Type', 'application/json');
       res.status(200).send(JSON.stringify(recipes));
-    // }
+    }
   })
   .catch(error => {
     res.setHeader('Content-Type', 'application/json');

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -52,4 +52,33 @@ router.get('/calorie_search', function(req, res, next) {
   });
 })
 
+router.get('/ingredient_search', function(req, res, next) {
+  Recipe.findAll({
+    where: {
+      foodType: req.query.q,
+      ingredientCount: req.query.num_of_ingredients
+    },
+    limit: 3
+  })
+  .then(recipes => {
+    // if (recipes.length < 3) {
+    //   edamamService.foodType(req.query.q)
+    //   .then(data => {
+    //     Recipe.bulkCreate(data)
+    //     .then(recipeResources => {
+    //       res.setHeader('Content-Type', 'application/json');
+    //       res.status(200).send(JSON.stringify(recipeResources));
+    //     })
+    //   })
+    // } else {
+      res.setHeader('Content-Type', 'application/json');
+      res.status(200).send(JSON.stringify(recipes));
+    // }
+  })
+  .catch(error => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(500).send({error});
+  });
+})
+
 module.exports = router;

--- a/services/edamam.js
+++ b/services/edamam.js
@@ -3,27 +3,27 @@ const fetch = require('node-fetch')
 
 class Edamam {
   foodType(query) {
-   return fetch(`https://api.edamam.com/search?q=${query}&app_id=${process.env.EDAMAM_API_ID}&app_key=${process.env.EDAMAM_API_KEY}&to=3&health=alcohol-free`)
-   .then(response => {
-     return response.json()
-     .then(json => {
-       let recipes = []
-       json.hits.forEach(function(recipe) {
-         recipes.push({
-           name: recipe.recipe.label,
-           foodType: query,
-           recipeUrl: recipe.recipe.url,
-           recipeImage: recipe.recipe.image,
-           ingredientList: recipe.recipe.ingredientLines.join(','),
-           ingredientCount: recipe.recipe.ingredientLines.length,
-           calorieCount: recipe.recipe.calories,
-           servingCount: recipe.recipe.yield
-         })
-       })
-       return recipes
-     })
-   })
- }
+    return fetch(`https://api.edamam.com/search?q=${query}&app_id=${process.env.EDAMAM_API_ID}&app_key=${process.env.EDAMAM_API_KEY}&to=3&health=alcohol-free`)
+    .then(response => {
+      return response.json()
+      .then(json => {
+        let recipes = []
+        json.hits.forEach(function(recipe) {
+          recipes.push({
+            name: recipe.recipe.label,
+            foodType: query,
+            recipeUrl: recipe.recipe.url,
+            recipeImage: recipe.recipe.image,
+            ingredientList: recipe.recipe.ingredientLines.join(','),
+            ingredientCount: recipe.recipe.ingredientLines.length,
+            calorieCount: recipe.recipe.calories,
+            servingCount: recipe.recipe.yield
+          })
+        })
+        return recipes
+      })
+    })
+  }
 
   ingredientCount(query, num_of_ingredients) {
     return fetch(`https://api.edamam.com/search?q=${query}&ingr=${num_of_ingredients}&app_id=${process.env.EDAMAM_API_ID}&app_key=${process.env.EDAMAM_API_KEY}&to=3&health=alcohol-free`)
@@ -48,8 +48,6 @@ class Edamam {
     })
   }
 }
-
-
 
 module.exports = {
   Edamam: Edamam

--- a/services/edamam.js
+++ b/services/edamam.js
@@ -24,7 +24,32 @@ class Edamam {
      })
    })
  }
+
+  ingredientCount(query, num_of_ingredients) {
+    return fetch(`https://api.edamam.com/search?q=${query}&ingr=${num_of_ingredients}&app_id=${process.env.EDAMAM_API_ID}&app_key=${process.env.EDAMAM_API_KEY}&to=3&health=alcohol-free`)
+    .then(response => {
+      return response.json()
+      .then(json => {
+        let recipes = []
+        json.hits.forEach(function(recipe) {
+          recipes.push({
+            name: recipe.recipe.label,
+            foodType: query,
+            recipeUrl: recipe.recipe.url,
+            recipeImage: recipe.recipe.image,
+            ingredientList: recipe.recipe.ingredientLines.join(','),
+            ingredientCount: recipe.recipe.ingredientLines.length,
+            calorieCount: recipe.recipe.calories,
+            servingCount: recipe.recipe.yield
+          })
+        })
+        return recipes
+      })
+    })
+  }
 }
+
+
 
 module.exports = {
   Edamam: Edamam

--- a/test/ingredient_count.spec.js
+++ b/test/ingredient_count.spec.js
@@ -98,7 +98,7 @@ describe('Ingredient Count api', () => {
         .then(recipes => {
           expect(recipes.length).toBe(0)
 
-          return request(app).get('/api/v1/recipes/food_search?q=turkey')
+          return request(app).get('/api/v1/recipes/ingredient_search?q=turkey&num_of_ingredients=3')
           .then(response => {
             expect(response.statusCode).toBe(200)
             expect(response.body.length).toBe(3)

--- a/test/ingredient_count.spec.js
+++ b/test/ingredient_count.spec.js
@@ -1,0 +1,93 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+var cleanup = require('./helper/testCleanup');
+var Recipe = require('../models').Recipe
+
+describe('Ingredient Count api', () => {
+  beforeEach(() => {
+    cleanup(Recipe)
+  })
+
+  describe('Test Recipe path', () => {
+    test('it can get recipes by ingredientCount when they exist in the database', () => {
+      return Recipe.bulkCreate([{
+        name: 'chicken dish',
+        foodType: 'chicken',
+        recipeUrl: 'www.chicken_recipe.com',
+        recipeImage: 'image.com',
+        ingredientList: '1 Chicken, 2 Lemons',
+        ingredientCount: 2,
+        calorieCount: 2000,
+        servingCount: 4
+      },
+      {
+        name: 'chicken dish',
+        foodType: 'chicken',
+        recipeUrl: 'www.chicken_recipe.com',
+        recipeImage: 'image.com',
+        ingredientList: '1 Chicken, 2 Lemons',
+        ingredientCount: 2,
+        calorieCount: 2000,
+        servingCount: 4
+      },
+      {
+        name: 'chicken dish',
+        foodType: 'chicken',
+        recipeUrl: 'www.chicken_recipe.com',
+        recipeImage: 'image.com',
+        ingredientList: '1 Chicken, 2 Lemons',
+        ingredientCount: 2,
+        calorieCount: 2000,
+        servingCount: 4
+      }])
+      .then(recipes => {
+        return request(app).get('/api/v1/recipes/ingredient_search?q=chicken&num_of_ingredients=2')
+        .then(response => {
+          expect(response.statusCode).toBe(200)
+          expect(response.body.length).toBe(3)
+          expect(Object.keys(response.body[0])).toContain('id')
+          expect(Object.keys(response.body[0])).toContain('name')
+          expect(Object.keys(response.body[0])).toContain('recipeUrl')
+          expect(Object.keys(response.body[0])).toContain('recipeImage')
+          expect(Object.keys(response.body[0])).toContain('ingredientList')
+          expect(Object.keys(response.body[0])).toContain('calorieCount')
+          expect(Object.keys(response.body[0])).toContain('servingCount')
+        })
+      })
+    })
+
+    // test('it can return recipes if none are on the database, and adds these new recipes', () => {
+    //   return Recipe.findAll({
+    //     where: {
+    //       foodType: 'turkey'
+    //     }
+    //   })
+    //   .then(recipes => {
+    //     expect(recipes.length).toBe(0)
+    //
+    //     return request(app).get('/api/v1/recipes/food_search?q=turkey')
+    //     .then(response => {
+    //       expect(response.statusCode).toBe(200)
+    //       expect(response.body.length).toBe(3)
+    //       expect(Object.keys(response.body[0])).toContain('id')
+    //       expect(Object.keys(response.body[0])).toContain('name')
+    //       expect(Object.keys(response.body[0])).toContain('recipeUrl')
+    //       expect(Object.keys(response.body[0])).toContain('recipeImage')
+    //       expect(Object.keys(response.body[0])).toContain('ingredientList')
+    //       expect(Object.keys(response.body[0])).toContain('calorieCount')
+    //       expect(Object.keys(response.body[0])).toContain('servingCount')
+    //
+    //       return Recipe.findAll({
+    //         where: {
+    //           foodType: 'turkey'
+    //         }
+    //       })
+    //       .then(recipes => {
+    //         expect(recipes.length).toBe(3)
+    //       })
+    //     })
+    //   })
+    // })
+  })
+})

--- a/test/ingredient_count.spec.js
+++ b/test/ingredient_count.spec.js
@@ -57,37 +57,71 @@ describe('Ingredient Count api', () => {
       })
     })
 
-    // test('it can return recipes if none are on the database, and adds these new recipes', () => {
-    //   return Recipe.findAll({
-    //     where: {
-    //       foodType: 'turkey'
-    //     }
-    //   })
-    //   .then(recipes => {
-    //     expect(recipes.length).toBe(0)
-    //
-    //     return request(app).get('/api/v1/recipes/food_search?q=turkey')
-    //     .then(response => {
-    //       expect(response.statusCode).toBe(200)
-    //       expect(response.body.length).toBe(3)
-    //       expect(Object.keys(response.body[0])).toContain('id')
-    //       expect(Object.keys(response.body[0])).toContain('name')
-    //       expect(Object.keys(response.body[0])).toContain('recipeUrl')
-    //       expect(Object.keys(response.body[0])).toContain('recipeImage')
-    //       expect(Object.keys(response.body[0])).toContain('ingredientList')
-    //       expect(Object.keys(response.body[0])).toContain('calorieCount')
-    //       expect(Object.keys(response.body[0])).toContain('servingCount')
-    //
-    //       return Recipe.findAll({
-    //         where: {
-    //           foodType: 'turkey'
-    //         }
-    //       })
-    //       .then(recipes => {
-    //         expect(recipes.length).toBe(3)
-    //       })
-    //     })
-    //   })
-    // })
+    test('it can return recipes if none are on the database, and adds these new recipes', () => {
+      return Recipe.bulkCreate([{
+        name: 'turkey dish',
+        foodType: 'turkey',
+        recipeUrl: 'www.turkey_recipe.com',
+        recipeImage: 'image.com',
+        ingredientList: '1 Turkey, 2 Lemons',
+        ingredientCount: 2,
+        calorieCount: 2000,
+        servingCount: 4
+      },
+      {
+        name: 'turkey dish',
+        foodType: 'turkey',
+        recipeUrl: 'www.turkey_recipe.com',
+        recipeImage: 'image.com',
+        ingredientList: '1 Turkey, 2 Lemons',
+        ingredientCount: 2,
+        calorieCount: 2000,
+        servingCount: 4
+      },
+      {
+        name: 'turkey dish',
+        foodType: 'turkey',
+        recipeUrl: 'www.turkey_recipe.com',
+        recipeImage: 'image.com',
+        ingredientList: '1 Turkey, 2 Lemons',
+        ingredientCount: 2,
+        calorieCount: 2000,
+        servingCount: 4
+      }])
+      .then(twoCountRecipes => {
+        return Recipe.findAll({
+          where: {
+            foodType: 'turkey',
+            ingredientCount: 3
+          }
+        })
+        .then(recipes => {
+          expect(recipes.length).toBe(0)
+
+          return request(app).get('/api/v1/recipes/food_search?q=turkey')
+          .then(response => {
+            expect(response.statusCode).toBe(200)
+            expect(response.body.length).toBe(3)
+            expect(Object.keys(response.body[0])).toContain('id')
+            expect(Object.keys(response.body[0])).toContain('name')
+            expect(Object.keys(response.body[0])).toContain('recipeUrl')
+            expect(Object.keys(response.body[0])).toContain('recipeImage')
+            expect(Object.keys(response.body[0])).toContain('ingredientList')
+            expect(Object.keys(response.body[0])).toContain('calorieCount')
+            expect(Object.keys(response.body[0])).toContain('servingCount')
+
+            return Recipe.findAll({
+              where: {
+                foodType: 'turkey',
+                ingredientCount: 3
+              }
+            })
+            .then(recipes => {
+              expect(recipes.length).toBe(3)
+            })
+          })
+        })
+      })
+    })
   })
 })

--- a/test/services/edamam.spec.js
+++ b/test/services/edamam.spec.js
@@ -24,4 +24,22 @@ describe('Edamam API Service Tests', () => {
       expect(Object.keys(recipes[0])).toContain('servingCount')
     })
   })
+
+  test('It can get recipes by food type and ingredient count', () => {
+    return edamamService.ingredientCount('turkey', 5)
+    .then(recipes => {
+      expect(recipes.length).toBe(3)
+      expect(Object.keys(recipes[0])).toContain('name')
+      expect(recipes[0].foodType).toBe('turkey')
+      expect(Object.keys(recipes[0])).toContain('recipeUrl')
+      expect(Object.keys(recipes[0])).toContain('recipeImage')
+      expect(Object.keys(recipes[0])).toContain('ingredientList')
+      expect(Object.keys(recipes[0])).toContain('ingredientCount')
+      expect(Object.keys(recipes[0])).toContain('calorieCount')
+      expect(Object.keys(recipes[0])).toContain('servingCount')
+      expect(recipes[0].ingredientCount).toBe(5)
+      expect(recipes[1].ingredientCount).toBe(5)
+      expect(recipes[2].ingredientCount).toBe(5)
+    })
+  })
 })

--- a/test/services/edamam.spec.js
+++ b/test/services/edamam.spec.js
@@ -26,7 +26,7 @@ describe('Edamam API Service Tests', () => {
   })
 
   test('It can get recipes by food type and ingredient count', () => {
-    return edamamService.ingredientCount('turkey', 5)
+    return edamamService.ingredientCount('turkey', 3)
     .then(recipes => {
       expect(recipes.length).toBe(3)
       expect(Object.keys(recipes[0])).toContain('name')
@@ -37,9 +37,9 @@ describe('Edamam API Service Tests', () => {
       expect(Object.keys(recipes[0])).toContain('ingredientCount')
       expect(Object.keys(recipes[0])).toContain('calorieCount')
       expect(Object.keys(recipes[0])).toContain('servingCount')
-      expect(recipes[0].ingredientCount).toBe(5)
-      expect(recipes[1].ingredientCount).toBe(5)
-      expect(recipes[2].ingredientCount).toBe(5)
+      expect(recipes[0].ingredientCount).toBe(3)
+      expect(recipes[1].ingredientCount).toBe(3)
+      expect(recipes[2].ingredientCount).toBe(3)
     })
   })
 })


### PR DESCRIPTION
This PR brings in the functionality for our microservice to have an `ingredient_search` endpoint, which takes in a `q` for a type of food for a Recipe, and a `num_of_ingredients` for the number of ingredients in that Recipe. This works similarly to the functionality for the previous endpoints, where if enough Recipes are in our database that follow these params, they will be returned, otherwise reaching out to Edamam to fill out our DB.
There was also some basic cleanup here and there with spacing and indentation.

resolves #3 