### PR TITLE
Sorted Recipes by Ingredients

### DIFF
--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -99,7 +99,8 @@ router.get('/ingredient_search', function(req, res, next) {
 router.get('/ingredient_sort', function(req, res, next) {
   let direction = req.query.amount == 'asc' ? 'ASC' : 'DESC'
   Recipe.findAll({
-    order: [['ingredientCount', direction]]
+    order: [['ingredientCount', direction]],
+    limit: 5
   })
   .then(recipes => {
     res.setHeader('Content-Type', 'application/json');

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -97,8 +97,9 @@ router.get('/ingredient_search', function(req, res, next) {
 })
 
 router.get('/ingredient_sort', function(req, res, next) {
+  let direction = req.query.amount == 'asc' ? 'ASC' : 'DESC'
   Recipe.findAll({
-    order: [['ingredientCount', 'DESC']]
+    order: [['ingredientCount', direction]]
   })
   .then(recipes => {
     res.setHeader('Content-Type', 'application/json');

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -96,4 +96,18 @@ router.get('/ingredient_search', function(req, res, next) {
   });
 })
 
+router.get('/ingredient_sort', function(req, res, next) {
+  Recipe.findAll({
+    order: [['ingredientCount', 'DESC']]
+  })
+  .then(recipes => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(200).send(JSON.stringify(recipes));
+  })
+  .catch(error => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(500).send({error});
+  })
+})
+
 module.exports = router;

--- a/test/ingredient_sort.spec.js
+++ b/test/ingredient_sort.spec.js
@@ -53,4 +53,49 @@ describe('Ingredient Count Sorted Recipes Endpoint', () => {
       })
     })
   })
+
+  test('it can return a sorted list of ingredients ascending', () => {
+    return Recipe.bulkCreate([{
+      name: 'chicken dish',
+      foodType: 'chicken',
+      recipeUrl: 'www.chicken_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Chicken, 2 Lemons',
+      ingredientCount: 5,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'turkey dish',
+      foodType: 'turkey',
+      recipeUrl: 'www.turkey_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Turkey, 2 Lemons',
+      ingredientCount: 2,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'pheasant dish',
+      foodType: 'pheasant',
+      recipeUrl: 'www.pheasant_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Pheasant, 2 Lemons',
+      ingredientCount: 10,
+      calorieCount: 2000,
+      servingCount: 4
+    }])
+    .then(chickens => {
+      return request(app).get('/api/v1/recipes/ingredient_sort?amount=asc')
+      .then(response => {
+        expect(response.status).toBe(200)
+        expect(response.body[0].name).toBe('turkey dish')
+        expect(response.body[0].ingredientCount).toBe(2)
+        expect(response.body[1].name).toBe('chicken dish')
+        expect(response.body[1].ingredientCount).toBe(5)
+        expect(response.body[2].name).toBe('pheasant dish')
+        expect(response.body[2].ingredientCount).toBe(10)
+      })
+    })
+  })
 })

--- a/test/ingredient_sort.spec.js
+++ b/test/ingredient_sort.spec.js
@@ -98,4 +98,73 @@ describe('Ingredient Count Sorted Recipes Endpoint', () => {
       })
     })
   })
+
+  test('it returns only 5 recipes in a sorted list of ingredients descending', () => {
+    return Recipe.bulkCreate([{
+      name: 'chicken dish',
+      foodType: 'chicken',
+      recipeUrl: 'www.chicken_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Chicken, 2 Lemons',
+      ingredientCount: 5,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'turkey dish',
+      foodType: 'turkey',
+      recipeUrl: 'www.turkey_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Turkey, 2 Lemons',
+      ingredientCount: 2,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'emu dish',
+      foodType: 'emu',
+      recipeUrl: 'www.emu_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Emu, 2 Lemons',
+      ingredientCount: 2,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'dodo dish',
+      foodType: 'dodo',
+      recipeUrl: 'www.dodo_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Dodo, 2 Lemons',
+      ingredientCount: 2,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'moa dish',
+      foodType: 'moa',
+      recipeUrl: 'www.moa_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Moa, 2 Lemons',
+      ingredientCount: 2,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'pheasant dish',
+      foodType: 'pheasant',
+      recipeUrl: 'www.pheasant_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Pheasant, 2 Lemons',
+      ingredientCount: 10,
+      calorieCount: 2000,
+      servingCount: 4
+    }])
+    .then(chickens => {
+      return request(app).get('/api/v1/recipes/ingredient_sort?amount=desc')
+      .then(response => {
+        expect(response.body.length).toBe(5)
+      })
+    })
+  })
 })

--- a/test/ingredient_sort.spec.js
+++ b/test/ingredient_sort.spec.js
@@ -1,0 +1,56 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+var cleanup = require('./helper/testCleanup');
+var Recipe = require('../models').Recipe
+
+describe('Ingredient Count Sorted Recipes Endpoint', () => {
+  beforeEach(() => {
+    cleanup(Recipe)
+  })
+
+  test('it can return a sorted list of ingredients descending', () => {
+    return Recipe.bulkCreate([{
+      name: 'chicken dish',
+      foodType: 'chicken',
+      recipeUrl: 'www.chicken_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Chicken, 2 Lemons',
+      ingredientCount: 5,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'turkey dish',
+      foodType: 'turkey',
+      recipeUrl: 'www.turkey_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Turkey, 2 Lemons',
+      ingredientCount: 2,
+      calorieCount: 2000,
+      servingCount: 4
+    },
+    {
+      name: 'pheasant dish',
+      foodType: 'pheasant',
+      recipeUrl: 'www.pheasant_recipe.com',
+      recipeImage: 'image.com',
+      ingredientList: '1 Pheasant, 2 Lemons',
+      ingredientCount: 10,
+      calorieCount: 2000,
+      servingCount: 4
+    }])
+    .then(chickens => {
+      return request(app).get('/api/v1/recipes/ingredient_sort?amount=desc')
+      .then(response => {
+        expect(response.status).toBe(200)
+        expect(response.body[0].name).toBe('pheasant dish')
+        expect(response.body[0].ingredientCount).toBe(10)
+        expect(response.body[1].name).toBe('chicken dish')
+        expect(response.body[1].ingredientCount).toBe(5)
+        expect(response.body[2].name).toBe('turkey dish')
+        expect(response.body[2].ingredientCount).toBe(2)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR brings in the functionality to search our database for Recipes based on an Ascending or Descending number of ingredients. This does require Recipes to already be in the DB, and will not reach out to Edamam to get more in the case there is a limited number.
The endpoint has logic to sort by Descending number of `ingredientCount` by default, and will search for Ascending if the correct string is given as a param.
It also will only limit the response to 5 Recipes to make things easier for the Frontend.